### PR TITLE
35 - Refactor UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "replicad-opencascadejs": "^0.15.2",
         "replicad-threejs-helper": "^0.15.2",
         "styled-components": "^6.1.8",
-        "three": "0.148.0",
+        "three": "0.161.0",
         "typescript": "^5.3.3",
         "zod": "^3.22.4"
       },
@@ -3173,9 +3173,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.148.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.148.0.tgz",
-      "integrity": "sha512-8uzVV+qhTPi0bOFs/3te3RW6hb3urL8jYEl6irjCWo/l6sr8MPNMcClFev/MMYeIxr0gmDcoXTy/8LXh/LXkfw=="
+      "version": "0.161.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.161.0.tgz",
+      "integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw=="
     },
     "node_modules/three-stdlib": {
       "version": "2.29.4",
@@ -5666,9 +5666,9 @@
       "requires": {}
     },
     "three": {
-      "version": "0.148.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.148.0.tgz",
-      "integrity": "sha512-8uzVV+qhTPi0bOFs/3te3RW6hb3urL8jYEl6irjCWo/l6sr8MPNMcClFev/MMYeIxr0gmDcoXTy/8LXh/LXkfw=="
+      "version": "0.161.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.161.0.tgz",
+      "integrity": "sha512-LC28VFtjbOyEu5b93K0bNRLw1rQlMJ85lilKsYj6dgTu+7i17W+JCCEbvrpmNHF1F3NAUqDSWq50UD7w9H2xQw=="
     },
     "three-stdlib": {
       "version": "2.29.4",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,12 @@
     "replicad-opencascadejs": "^0.15.2",
     "replicad-threejs-helper": "^0.15.2",
     "styled-components": "^6.1.8",
-    "three": "0.148.0",
+    "three": "0.161.0",
     "typescript": "^5.3.3",
     "zod": "^3.22.4"
+  },
+  "overrides": {
+    "three": "0.161.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "3.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,8 +10,7 @@ import { ModelSettingsPanel } from "./components/ModelSettingsPanel/ModelSetting
 import { DrumSchema } from "./components/ModelSettingsPanel/inputSchema.ts";
 import { TailSpin } from "react-loader-spinner";
 
-// @ts-expect-error - Property 'DefaultUp' does not exist on type 'typeof Object3D', however this code executes fine and is necessary to set the correct rotational axis
-THREE.Object3D.DefaultUp.set(0, 0, 1);
+THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
 
 const cad = wrap(new cadWorker());
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,21 +3,16 @@ import cadWorker from "./worker.js?worker";
 import React, { useState, useEffect } from "react";
 import * as THREE from "three";
 import { wrap, proxy } from "comlink";
-import PresentationViewer from "./replicad-studio-components/PresentationViewer.jsx";
 import JSZip from "jszip";
 import { fileSave } from "browser-fs-access";
 import { ModelSettingsPanel } from "./components/ModelSettingsPanel/ModelSettingsPanel.tsx";
 import { DrumSchema } from "./components/ModelSettingsPanel/inputSchema.ts";
-import { TailSpin } from "react-loader-spinner";
+import { defaultDrum } from "./model/defaultDrum.ts";
+import { ModelViewer } from "./components/ModelViewer.tsx";
 
 THREE.Object3D.DEFAULT_UP.set(0, 0, 1);
 
 const cad = wrap(new cadWorker());
-
-const convertToPercentage = (number) => {
-  const percentage = number * 100;
-  return percentage.toFixed(2) + "%";
-};
 
 const downloadModel = async () => {
   // @ts-expect-error - see TODO on line 1
@@ -45,59 +40,7 @@ export default function ReplicadApp() {
     progress: 0,
     messages: [],
   });
-  const [printableDrum, setPrintableDrum] = useState<DrumSchema>({
-    drumType: "snare",
-    fitmentTolerance: 0.2,
-    shell: {
-      diameterInches: 14,
-      depthInches: 6.5,
-      shellThickness: 10,
-      lugsPerSegment: 2,
-      ventHoleDiameter: 10,
-    },
-    lugs: {
-      lugType: "singlePoint",
-      lugRows: 1,
-      lugNumber: 8,
-      lugHoleSpacing: 20,
-      lugHoleDiameter: 5,
-      lugHolePocketDiameter: 8,
-      lugHolePocketDepth: 2,
-      lugHoleDistanceFromEdge: 40,
-    },
-    bearingEdges: {
-      lugsPerSegment: 2,
-      topBearingEdge: {
-        thickness: 10,
-        outerEdge: {
-          profileType: "roundover",
-          profileSize: 10 / 2,
-          customChamferAngle: 0,
-        },
-        innerEdge: {
-          profileType: "chamfer",
-          customChamferAngle: 0,
-        },
-      },
-      bottomBearingEdge: {
-        thickness: 10,
-        outerEdge: {
-          profileType: "roundover",
-          profileSize: 10 / 2,
-          customChamferAngle: 0,
-        },
-        innerEdge: {
-          profileType: "chamfer",
-          customChamferAngle: 0,
-        },
-      },
-    },
-    snareBeds: {
-      snareBedAngle: 10,
-      snareBedRadius: 400,
-      snareBedDepth: 2.5,
-    },
-  });
+  const [printableDrum, setPrintableDrum] = useState<DrumSchema>(defaultDrum);
 
   const updateModelProgress = (progress: number, message?: string) => {
     const modelProgressState = { ...modelProgress };
@@ -133,90 +76,36 @@ export default function ReplicadApp() {
   }, []);
 
   return (
-    <>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        background: `radial-gradient(
+          circle,
+          rgba(250, 250, 250, 1) 0%,
+          rgba(208, 212, 213, 1) 100%
+        )`,
+      }}
+    >
       <ModelSettingsPanel
         printableDrum={printableDrum}
         generateModel={generateModel}
         loading={loading}
+        style={{
+          width: "20%",
+          margin: "20px",
+          zIndex: 100,
+          height: "calc(100vh - 40px)",
+          borderRadius: "5px",
+        }}
       />
-      <section style={{ height: "100vh" }}>
-        <button
-          onClick={() => downloadModel()}
-          style={{
-            fontFamily: "Roboto",
-            height: "2em",
-            fontSize: "1em",
-            fontWeight: 550,
-            position: "absolute",
-            right: "0px",
-            margin: "20px",
-            zIndex: 100,
-          }}
-        >
-          {loading ? (
-            <TailSpin
-              visible={true}
-              height="20"
-              width="20"
-              color="#000"
-              ariaLabel="tail-spin-loading"
-              radius="1"
-              wrapperStyle={{
-                width: "100%",
-                display: "flex",
-                justifyContent: "center",
-              }}
-              wrapperClass=""
-            />
-          ) : (
-            "Download STL Files"
-          )}
-        </button>
-        {!loading && model ? (
-          <PresentationViewer
-            shapes={model}
-            hideGrid={true}
-            disableDamping={false}
-            disableAutoPosition={true}
-          />
-        ) : (
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              height: "100%",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: "2em",
-              fontFamily: "Roboto",
-              background: `radial-gradient(
-                  circle,
-                  rgba(250, 250, 250, 1) 0%,
-                  rgba(208, 212, 213, 1) 100%
-                )`,
-            }}
-          >
-            <span>{`Generating Drum Shell Model ${convertToPercentage(
-              modelProgress.progress
-            )}`}</span>
-            {modelProgress.messages.map((message, i) => {
-              const latestMessage = i + 1 === modelProgress.messages.length;
-              return (
-                <p
-                  style={{
-                    fontSize: "0.5em",
-                    margin: 0,
-                  }}
-                  key={i}
-                >
-                  {message}
-                  {latestMessage ? "..." : " ✔️"}
-                </p>
-              );
-            })}
-          </div>
-        )}
-      </section>
-    </>
+      <ModelViewer
+        downloadModel={downloadModel}
+        loading={loading}
+        model={model}
+        modelProgress={modelProgress}
+        style={{ height: "100vh", width: "80%" }}
+      />
+    </div>
   );
 }

--- a/src/components/ModelSettingsPanel/ModelSettingsPanel.tsx
+++ b/src/components/ModelSettingsPanel/ModelSettingsPanel.tsx
@@ -13,6 +13,7 @@ export const ModelSettingsPanel = ({
   printableDrum,
   generateModel,
   loading,
+  style,
 }) => {
   const [showDocumentation, setShowDocumentation] = useState(false);
   const {
@@ -52,11 +53,7 @@ export const ModelSettingsPanel = ({
         display: "flex",
         fontFamily: "Roboto",
         flexDirection: "row",
-        position: "absolute",
-        margin: "20px",
-        zIndex: 100,
-        height: "calc(100vh - 40px)",
-        borderRadius: "5px",
+        ...style,
       }}
     >
       <form
@@ -87,7 +84,7 @@ export const ModelSettingsPanel = ({
           }}
         >
           <h1 style={{ lineHeight: 1, margin: "10px" }}>Print-A-Drum</h1>
-          <p style={{marginTop: 0}}>
+          <p style={{ marginTop: 0 }}>
             {!showDocumentation && (
               <>
                 Need help?{" "}
@@ -166,7 +163,7 @@ export const ModelSettingsPanel = ({
             maxWidth: "calc(100vw - (370px * 2))",
           }}
         >
-          <div style={{margin: "0 0 10px 15px"}}>
+          <div style={{ margin: "0 0 10px 15px" }}>
             <a
               onClick={() => setShowDocumentation(!showDocumentation)}
               style={linkStyle}

--- a/src/components/ModelViewer.tsx
+++ b/src/components/ModelViewer.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { TailSpin } from "react-loader-spinner";
+import PresentationViewer from "../replicad-studio-components/PresentationViewer";
+
+const convertToPercentage = (number) => {
+  const percentage = number * 100;
+  return percentage.toFixed(2) + "%";
+};
+
+export const ModelViewer = ({
+  downloadModel,
+  loading,
+  model,
+  modelProgress,
+  style
+}) => (
+  <section style={style}>
+    <button
+      onClick={() => downloadModel()}
+      style={{
+        fontFamily: "Roboto",
+        height: "2em",
+        fontSize: "1em",
+        fontWeight: 550,
+        position: "absolute",
+        right: "0px",
+        margin: "20px",
+        zIndex: 100,
+      }}
+    >
+      {loading ? (
+        <TailSpin
+          visible={true}
+          height="20"
+          width="20"
+          color="#000"
+          ariaLabel="tail-spin-loading"
+          radius="1"
+          wrapperStyle={{
+            width: "100%",
+            display: "flex",
+            justifyContent: "center",
+          }}
+          wrapperClass=""
+        />
+      ) : (
+        "Download STL Files"
+      )}
+    </button>
+    {!loading && model ? (
+      <PresentationViewer
+        shapes={model}
+        hideGrid={true}
+        disableDamping={false}
+        disableAutoPosition={true}
+      />
+    ) : (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: "2em",
+          fontFamily: "Roboto",
+        }}
+      >
+        <span>{`Generating Drum Shell Model ${convertToPercentage(
+          modelProgress.progress
+        )}`}</span>
+        {modelProgress.messages.map((message, i) => {
+          const latestMessage = i + 1 === modelProgress.messages.length;
+          return (
+            <p
+              style={{
+                fontSize: "0.5em",
+                margin: 0,
+              }}
+              key={i}
+            >
+              {message}
+              {latestMessage ? "..." : " ✔️"}
+            </p>
+          );
+        })}
+      </div>
+    )}
+  </section>
+);

--- a/src/model/defaultDrum.ts
+++ b/src/model/defaultDrum.ts
@@ -1,0 +1,55 @@
+import { DrumSchema } from "../components/ModelSettingsPanel/inputSchema";
+
+export const defaultDrum: DrumSchema = {
+  drumType: "snare",
+  fitmentTolerance: 0.2,
+  shell: {
+    diameterInches: 14,
+    depthInches: 6.5,
+    shellThickness: 10,
+    lugsPerSegment: 2,
+    ventHoleDiameter: 10,
+  },
+  lugs: {
+    lugType: "singlePoint",
+    lugRows: 1,
+    lugNumber: 8,
+    lugHoleSpacing: 20,
+    lugHoleDiameter: 5,
+    lugHolePocketDiameter: 8,
+    lugHolePocketDepth: 2,
+    lugHoleDistanceFromEdge: 40,
+  },
+  bearingEdges: {
+    lugsPerSegment: 2,
+    topBearingEdge: {
+      thickness: 10,
+      outerEdge: {
+        profileType: "roundover",
+        profileSize: 10 / 2,
+        customChamferAngle: 0,
+      },
+      innerEdge: {
+        profileType: "chamfer",
+        customChamferAngle: 0,
+      },
+    },
+    bottomBearingEdge: {
+      thickness: 10,
+      outerEdge: {
+        profileType: "roundover",
+        profileSize: 10 / 2,
+        customChamferAngle: 0,
+      },
+      innerEdge: {
+        profileType: "chamfer",
+        customChamferAngle: 0,
+      },
+    },
+  },
+  snareBeds: {
+    snareBedAngle: 10,
+    snareBedRadius: 400,
+    snareBedDepth: 2.5,
+  },
+}

--- a/src/replicad-studio-components/Canvas.jsx
+++ b/src/replicad-studio-components/Canvas.jsx
@@ -6,12 +6,6 @@ import LoadingScreen from "./LoadingScreen.jsx";
 const StyledCanvas = styled(ThreeCanvas)`
   width: 100%;
   height: 100%;
-  background: rgb(250, 250, 250);
-  background: radial-gradient(
-    circle,
-    rgba(250, 250, 250, 1) 0%,
-    rgba(208, 212, 213, 1) 100%
-  );
 `;
 
 export default function Canvas({ children, ...props }) {


### PR DESCRIPTION
- Update `three` package to 0.161.0 and handle error with `DefaultUp` property
- Move `printableDrum` state initialiser into a separate file
- Create `ModelViewer` component to handle model rendering logic outside of the `App` component
- `ModelSettingsPanel` component is no longer absolutely positioned; it now sits next to `ModelViewer`